### PR TITLE
Don't include directories if `alwaysShowViewer` is active

### DIFF
--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -723,8 +723,14 @@ export default {
 				const [dirPath] = extractFilePaths(fileInfo.filename)
 				const fileList = await folderRequest(dirPath)
 
-				// filter out the unwanted mimes if configModule.alwaysShowViewer not enabled
-				const filteredFiles = configModule.alwaysShowViewer ? fileList : fileList.filter(file => file.mime && mimes.indexOf(file.mime) !== -1)
+				let filteredFiles
+				if (configModule.alwaysShowViewer) {
+					// don't include directories, otherwise accept all mimes
+					filteredFiles = fileList.filter(({ type }) => type !== 'directory')
+				} else {
+					// filter out the unwanted mimes
+					filteredFiles = fileList.filter(file => file.mime && mimes.indexOf(file.mime) !== -1)
+				}
 
 				// sort like the files list
 				// TODO: implement global sorting API


### PR DESCRIPTION
Don't include directories as they can not be displayed.

Note: including directories could also cause a follow-up error with certain directory structures which happen to include a directory named like a number (i.e. 123) because of sloppy, too broad type casting in fileUtils.ts's genFileInfo() accidentally converting such a folder name to a Number, which then can not be used in string comparisons.