### PR TITLE
Fix open in public view

### DIFF
--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -9,5 +9,5 @@ const alwaysShowViewer = loadState<boolean>('viewer', 'always_show_viewer', fals
 
 export default {
 	alwaysShowViewer,
-	defaultMimeType: '*/*',
+	defaultMimeType: 'all',
 }

--- a/src/models/default.ts
+++ b/src/models/default.ts
@@ -4,12 +4,13 @@
  */
 
 import Default from '../components/Default.vue'
+import config from './config.ts'
 
 export default {
 	id: 'default',
 	group: 'other',
 	mimes: [
-		'*/*',
+		config.defaultMimeType,
 	],
 	mimesAliases: {},
 	component: Default,


### PR DESCRIPTION
## The bug

The app config "always_show_viewer" enables the preview for all
mimetypes. If this config is not set and no handler is registered for a
mimetype, the file will be downloaded.

In the share/public view, with this config enabled some file types
were downloaded instead of opened in the preview.

The code would not progress up to Viewer's openFileInfo() because it
would not find a preview component candidate in [1] to even attempt
opening the preview.

## The fix

As per reverse engineering it was found that special string "all" is
used as symbol for handling any mimetype (at least in [2]).

The decision was made to change the special mimetype for a registered
previewer to "all", because then handling any file is already coverered
this way.

All discovered places:

1. Files/fileactions: getDefaultFileAction() [2]
2. Shares: attach(), "fileActionsReady" event handler, registerAction()
   call [3]

[1]: https://github.com/nextcloud/server/blob/v29.0.6/apps/files/js/filelist.js#L912
[2]: https://github.com/nextcloud/server/blob/v29.0.6/apps/files/js/fileactions.js#L315
[3]: https://github.com/nextcloud/server/blob/v29.0.6/apps/files_sharing/src/share.js#L230
