### PR TITLE
Fix broken image loading spinner

### DIFF
--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -126,7 +126,7 @@ export default {
 			shiftX: 0,
 			shiftY: 0,
 			zoomRatio: 1,
-			fallback: false,
+			previewFailed: false,
 			livePhotoCanBePlayed: false,
 		}
 	},
@@ -191,7 +191,7 @@ export default {
 			}
 
 			// If loading the preview failed once, let's load the original file
-			if (this.fallback) {
+			if (this.previewFailed) {
 				return this.src
 			}
 
@@ -351,9 +351,9 @@ export default {
 
 		// Fallback to the original image if not already done
 		onFail() {
-			if (!this.fallback) {
+			if (!this.previewFailed) {
 				console.error(`Loading of file preview ${basename(this.src)} failed, falling back to original file`)
-				this.fallback = true
+				this.previewFailed = true
 			}
 		},
 		doneLoadingLivePhoto() {


### PR DESCRIPTION
## The cause

Previously the code attempted to load a preview of an image.

If loading this preview image failed it was attempted to load the
original image.

Load errors of images were only handled _once_. This meant that a
load error for the original image was never handled, thus the
viewer was still in loading state and showed a browser-dependant
"broken image" replacement icon.

## The fix

Now further image load errors are handled too. In case the original
fails too, the loading state is ended and a placeholder text is shown.

The default preview component, which was introduced to show something
for any mimetype if configured, is now also used as a fallback.
