### PR TITLE
fix(Default): fix width for Safari

### DIFF
--- a/src/components/Default.vue
+++ b/src/components/Default.vue
@@ -52,7 +52,7 @@ img {
 	align-self: center;
 	justify-self: center;
 	margin-bottom: 16px;
-	width: 100%;
+	min-width: 100%;
 	height: 10em;
 }
 


### PR DESCRIPTION
For some reason, Safari needs 'min-width' instead of 'width' so that it won't (seemingly) randomly scale down the icons. :shrug: 