### PR TITLE
IONOS: fix(Viewer): fix image load error with number folder

### DIFF
--- a/lib/Listener/LoadViewerScript.php
+++ b/lib/Listener/LoadViewerScript.php
@@ -59,12 +59,12 @@ class LoadViewerScript implements IEventListener {
 		}
 
 		$alwaysShowViewer = $this->appConfig->getAppValue('always_show_viewer', 'no') === 'yes';
-		
+
 		Util::addStyle(Application::APP_ID, 'viewer-init');
 		Util::addStyle(Application::APP_ID, 'viewer-main');
 		Util::addInitScript(Application::APP_ID, 'viewer-init');
 		Util::addScript(Application::APP_ID, 'viewer-main', 'files');
 		$this->initialStateService->provideInitialState('enabled_preview_providers', array_keys($this->previewManager->getProviders()));
-		$this->initialStateService->provideInitialState("always_show_viewer", $alwaysShowViewer);
+		$this->initialStateService->provideInitialState('always_show_viewer', $alwaysShowViewer);
 	}
 }

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -77,8 +77,8 @@ const sortCompare = function(fileInfo1, fileInfo2, key, asc = true) {
 	}
 	// finally sort by name
 	return asc
-		? fileInfo1[key].localeCompare(fileInfo2[key], OC.getLanguage(), { numeric: true })
-		: -fileInfo1[key].localeCompare(fileInfo2[key], OC.getLanguage(), { numeric: true })
+		? fileInfo1[key].toString()?.localeCompare(fileInfo2[key].toString(), OC.getLanguage(), { numeric: true })
+		: -fileInfo1[key].toString()?.localeCompare(fileInfo2[key].toString(), OC.getLanguage(), { numeric: true })
 }
 
 export type FileInfo = object


### PR DESCRIPTION
Fixes a bug that a file cannot be opened if it is on the same level as a (shared) folder with a name that only contains numbers.
(Only happens with Firefox.)

Note: Very similar to https://github.com/nextcloud/photos/pull/783