### PR TITLE
do githhub jobs only on ionos-dev

### DIFF
--- a/.github/workflows/cypress-snapshot-update.yml
+++ b/.github/workflows/cypress-snapshot-update.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
         run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
 
+      - name: Install IONOS dependencies
+        run: |
+            echo "install dependencies from stable30 as fallback" \
+            npm install @mdi/svg@^7.4.47 @nextcloud/vue@^8.22.0 vue-material-design-icons@^5.3.1
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/cypress-snapshot-update.yml
+++ b/.github/workflows/cypress-snapshot-update.yml
@@ -13,8 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ["main", "master", "stable27", "stable26"]
-  
+#        branches: ["main", "master", "stable27", "stable26"]
+        branches: ["ionos-dev"]
+
     name: cypress-snapshot-update-${{ matrix.branches }}
 
     steps:

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -21,7 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable29', 'stable28', 'stable27']
+#        branches: ['main', 'master', 'stable29', 'stable28', 'stable27']
+        branches: ['ionos-dev']
 
     name: npm-audit-fix-${{ matrix.branches }}
 


### PR DESCRIPTION
we care only about current version (30)
COMMAND_BOT_PAT secret is missing in order for: 

- cypress-snapshot-update.yml
- npm-audit-fix.yml

to execute