### PR TITLE
IONOS(file-utils): preserve numeric names for filename and basename a…

### DIFF
--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -104,6 +104,11 @@ const genFileInfo = function(obj: FileStat): FileInfo {
 			} else if (data === 'true') {
 				fileInfo[camelcase(key)] = true
 			} else {
+				// preserve numeric names for filename and basename as string
+				if (key === 'filename' || key === 'basename') {
+					fileInfo[camelcase(key)] = data
+					return
+				}
 				fileInfo[camelcase(key)] = isNumber(data)
 					? Number(data)
 					: data


### PR DESCRIPTION
…s string

* in order to ensure proper sorting
* see FileStat interface in webdav package https://github.com/perry-mitchell/webdav-client/blob/0e3520fcb94767686653fa87f2b0be2f2cb26659/source/types.ts#L124

Proposed a PR to NC https://github.com/nextcloud/viewer/pull/2741