### PR TITLE
IONOS(viewer): NC33 IONOS delta — one commit per feature (HDNEXT-1585)

### DIFF
--- a/lib/Listener/LoadViewerScript.php
+++ b/lib/Listener/LoadViewerScript.php
@@ -11,6 +11,7 @@ namespace OCA\Viewer\Listener;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Viewer\AppInfo\Application;
 use OCA\Viewer\Event\LoadViewer;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -28,6 +29,7 @@ class LoadViewerScript implements IEventListener {
 	public function __construct(
 		IInitialState $initialStateService,
 		IPreview $previewManager,
+		private readonly IAppConfig $appConfig,
 	) {
 		$this->initialStateService = $initialStateService;
 		$this->previewManager = $previewManager;
@@ -39,9 +41,13 @@ class LoadViewerScript implements IEventListener {
 		}
 
 		Util::addStyle(Application::APP_ID, 'viewer-init');
+
+		$alwaysShowViewer = $this->appConfig->getAppValue('always_show_viewer', 'no') === 'yes';
+
 		Util::addStyle(Application::APP_ID, 'viewer-main');
 		Util::addInitScript(Application::APP_ID, 'viewer-init');
 		Util::addScript(Application::APP_ID, 'viewer-main', 'files');
 		$this->initialStateService->provideInitialState('enabled_preview_providers', array_keys($this->previewManager->getProviders()));
+		$this->initialStateService->provideInitialState('always_show_viewer', $alwaysShowViewer);
 	}
 }

--- a/src/components/Default.vue
+++ b/src/components/Default.vue
@@ -1,0 +1,69 @@
+<!--
+  - SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-FileCopyrightText: 2024 STRATO AG
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="default_container">
+		<img :src="mimeIcon" alt="mimetype-icon">
+		<span class="title">
+			{{ basename }}
+		</span>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'Default',
+
+	props: {
+		basename: {
+			type: String,
+			default: '',
+		},
+		mime: {
+			type: String,
+			default: '',
+		},
+	},
+
+	computed: {
+		mimeIcon() {
+			return OC.MimeType.getIconUrl(this.mime)
+		},
+	},
+
+	mounted() {
+		if (typeof this.doneLoading === 'function') {
+			this.doneLoading()
+		}
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.default_container {
+	display: flex;
+	align-items: center;
+	height: 100%;
+	justify-content: center;
+	flex-direction: column;
+}
+
+img {
+	align-self: center;
+	justify-self: center;
+	margin-bottom: 16px;
+	min-width: 100%;
+	height: 10em;
+}
+
+.title {
+	color: var(--color-primary-text);
+	font-weight: bold;
+	font-size: 1.4em;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+</style>

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -12,7 +12,8 @@
 			@close="onClose" />
 
 		<template v-else-if="data !== null">
-			<img v-if="!livePhotoCanBePlayed"
+			<Default v-if="originalFailed" :basename="basename" :mime="mime" />
+			<img v-else-if="!livePhotoCanBePlayed"
 				ref="image"
 				:alt="alt"
 				:class="{
@@ -22,7 +23,7 @@
 				}"
 				:src="data"
 				:style="imgStyle"
-				@error.capture.prevent.stop.once="onFail"
+				@error.capture.prevent.stop="onFail"
 				@load="updateImgSize"
 				@wheel.stop.prevent="updateZoom"
 				@dblclick.prevent="onDblclick"
@@ -83,6 +84,7 @@ import { basename } from '@nextcloud/paths'
 import { translate } from '@nextcloud/l10n'
 import { NcLoadingIcon } from '@nextcloud/vue'
 
+import Default from './Default.vue'
 import ImageEditor from './ImageEditor.vue'
 import { findLivePhotoPeerFromFileId } from '../utils/livePhotoUtils'
 import { getDavPath } from '../utils/fileUtils'
@@ -94,6 +96,7 @@ export default {
 	name: 'Images',
 
 	components: {
+		Default,
 		ImageEditor,
 		PlayCircleOutline,
 		NcLoadingIcon,
@@ -112,6 +115,7 @@ export default {
 			shiftY: 0,
 			zoomRatio: 1,
 			fallback: false,
+			originalFailed: false,
 			livePhotoCanBePlayed: false,
 			zooming: false,
 			pinchDistance: 0,
@@ -422,9 +426,17 @@ export default {
 
 		// Fallback to the original image if not already done
 		onFail() {
+			if (this.originalFailed) {
+				// Loading the original image was already attempted, don't bother handling more errors
+				return
+			}
 			if (!this.fallback) {
 				console.error(`Loading of file preview ${basename(this.src)} failed, falling back to original file`)
 				this.fallback = true
+			} else {
+				this.originalFailed = true
+				console.error(`Loading of the original image ${basename(this.source)} failed too`)
+				this.doneLoading()
 			}
 		},
 		doneLoadingLivePhoto() {

--- a/src/files_actions/viewerAction.ts
+++ b/src/files_actions/viewerAction.ts
@@ -10,6 +10,7 @@ import { emit } from '@nextcloud/event-bus'
 import { t } from '@nextcloud/l10n'
 import svgEye from '@mdi/svg/svg/eye.svg?raw'
 
+import configModule from '../models/config.ts'
 import logger from '../services/logger.js'
 
 /**
@@ -104,6 +105,12 @@ export function registerViewerAction() {
 			// Disable if not located in user root
 			if (nodes.some(node => !(node.isDavResource && node.root?.startsWith('/files')))) {
 				return false
+			}
+
+			// Always enabled if configured so
+			if (configModule.alwaysShowViewer) {
+				// disable for folders
+				return !nodes.some(node => node.type === 'folder')
 			}
 
 			return nodes.every((node) =>

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: 2024 STRATO AG
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { loadState } from '@nextcloud/initial-state'
+
+const alwaysShowViewer = loadState<boolean>('viewer', 'always_show_viewer', false)
+
+export default {
+	alwaysShowViewer,
+	defaultMimeType: 'all',
+}

--- a/src/models/default.ts
+++ b/src/models/default.ts
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: 2024 STRATO AG
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import Default from '../components/Default.vue'
+import config from './config.ts'
+
+export default {
+	id: 'default',
+	group: 'other',
+	mimes: [
+		config.defaultMimeType,
+	],
+	mimesAliases: {},
+	component: Default,
+}

--- a/src/services/Viewer.js
+++ b/src/services/Viewer.js
@@ -6,6 +6,7 @@
 import Images from '../models/images.js'
 import Videos from '../models/videos.js'
 import Audios from '../models/audios.js'
+import Default from '../models/default.ts'
 import logger from './logger.js'
 
 /**
@@ -62,6 +63,7 @@ export default class Viewer {
 		this.registerHandler(Images)
 		this.registerHandler(Videos)
 		this.registerHandler(Audios)
+		this.registerHandler(Default)
 
 		logger.debug('OCA.Viewer initialized')
 	}

--- a/src/utils/livePhotoUtils.ts
+++ b/src/utils/livePhotoUtils.ts
@@ -26,6 +26,6 @@ export function findLivePhotoPeerFromName(referenceFile: BasicFileInfo, fileList
 	return fileList.find(comparedFile => {
 		// if same filename and extension is allowed
 		return comparedFile.filename !== referenceFile.filename
-				&& (comparedFile.basename.startsWith(referenceFile.name) && livePictureExtRegex.test(comparedFile.basename))
+			&& (comparedFile.basename.toString().startsWith(referenceFile.name) && livePictureExtRegex.test(comparedFile.basename))
 	})
 }

--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -785,8 +785,14 @@ export default defineComponent({
 
 				const fileList = await folderRequest(dirPath)
 
-				// filter out the unwanted mimes
-				const filteredFiles = fileList.filter(file => file.mime && mimes.indexOf(file.mime) !== -1)
+				let filteredFiles
+				if (configModule.alwaysShowViewer) {
+					// only include files with mime to exclude directories, otherwise accept all mimes
+					filteredFiles = fileList.filter(file => file?.mime)
+				} else {
+					// filter out the unwanted mimes
+					filteredFiles = fileList.filter(file => file.mime && mimes.indexOf(file.mime) !== -1)
+				}
 
 				// sort like the files list
 				// TODO: implement global sorting API

--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -44,7 +44,7 @@
 		:inline-actions="canEdit ? 1 : 0"
 		:spread-navigation="true"
 		:style="{ width: isSidebarShown ? `${sidebarPosition}px` : null }"
-		:name="currentFile.basename"
+		:name="modalTitle"
 		class="viewer"
 		size="full"
 		@close="close"
@@ -389,6 +389,14 @@ export default defineComponent({
 				'theme--default': this.theme === 'default',
 				'image--fullscreen': this.isImage && this.isFullscreenMode,
 			}
+		},
+
+		modalTitle() {
+			if (!configModule.alwaysShowViewer) {
+				return this.currentFile.basename
+			}
+
+			return this.currentFile?.modal?.name === 'Default' ? '' : this.currentFile.basename
 		},
 
 		showComparison() {
@@ -1334,6 +1342,14 @@ export default defineComponent({
 			background-color: transparent;
 			box-shadow: none;
 		}
+	}
+
+	// The header actions (play/pause, actions menu, close) are normally pushed
+	// to the right by the full-width `.modal-header__name` element. When the
+	// modal name is empty (Default handler / always-show-viewer), NcModal omits
+	// that element, so keep the menu right-aligned explicitly.
+	:deep(.modal-header .icons-menu) {
+		margin-inline-start: auto;
 	}
 
 	&__content {

--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -787,8 +787,16 @@ export default defineComponent({
 
 				let filteredFiles
 				if (configModule.alwaysShowViewer) {
-					// only include files with mime to exclude directories, otherwise accept all mimes
-					filteredFiles = fileList.filter(file => file?.mime)
+					// only include files with mime to exclude directories
+					// and office documents/pdfs to exclude collabora files
+					// otherwise accept all mimes
+					filteredFiles = fileList.filter(file => {
+						const mime = file?.mime
+						const isOfficeDocument = mime && OC.MimeTypeList.aliases[mime]?.startsWith('x-office')
+						const isPdf = mime && mime === 'application/pdf'
+
+						return mime && !isOfficeDocument && !isPdf
+					})
 				} else {
 					// filter out the unwanted mimes
 					filteredFiles = fileList.filter(file => file.mime && mimes.indexOf(file.mime) !== -1)

--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -192,6 +192,7 @@ import { canDownload } from '../utils/canDownload.ts'
 import { extractFilePaths, extractFilePathFromSource } from '../utils/fileUtils.ts'
 import { toggleEditor } from '../files_actions/viewerAction.ts'
 import cancelableRequest from '../utils/CancelableRequest.js'
+import configModule from '../models/config.ts'
 import Error from '../components/Error.vue'
 import fetchNode from '../services/FetchFile.ts'
 import File from '../models/file.js'
@@ -728,6 +729,11 @@ export default defineComponent({
 				handler = this.registeredHandlers[mime] ?? this.registeredHandlers[alias]
 			}
 
+			// fallback to default viewer if enabled
+			if (!handler && configModule.alwaysShowViewer) {
+				handler = this.registeredHandlers[configModule.defaultMimeType]
+			}
+
 			// if we don't have a handler for this mime, abort
 			if (!handler) {
 				logger.error('The following file could not be displayed', { fileInfo })
@@ -745,8 +751,10 @@ export default defineComponent({
 			this.comparisonFile = null
 			this.updatePreviousNext()
 
+			// fallback to default viewer group if enabled
+			const groupFallback = configModule.alwaysShowViewer ? this.mimeGroups[configModule.defaultMimeType] : undefined
 			// check if part of a group, if so retrieve full files list
-			const group = this.mimeGroups[mime]
+			const group = this.mimeGroups[mime] ?? groupFallback
 			if (this.files && this.files.length > 0) {
 				logger.debug('A files list have been provided. No folder content will be fetched.')
 				// we won't sort files here, let's use the order the array has
@@ -814,7 +822,7 @@ export default defineComponent({
 		openFileFromList(fileInfo) {
 			// override mimetype if existing alias
 			const mime = fileInfo.mime
-			this.currentFile = new File(fileInfo, mime, this.components[mime])
+			this.currentFile = new File(fileInfo, mime, this.components[mime] || this.components[configModule.defaultMimeType])
 			this.changeSidebar()
 			this.updatePreviousNext()
 		},


### PR DESCRIPTION
## Summary

This is the **folded** variant of #45 — essentially the same IONOS viewer delta on the NC33 base
`ionos-dev-v33`, with the history reshaped to **one commit per feature** so it reads cleanly and is
ready to be proposed upstream to `nextcloud/viewer`.

Compared to #45 it additionally carries a small follow-up **header-layout fix** (see feature 2
below) and, for now, **omits the recompiled assets** — see the note at the bottom.

## Features (6 commits)

1. **feat(viewer): always-show-viewer with default fallback component** — the `always_show_viewer`
   app config, the config module, the Default component (+ its text-color / Safari-width /
   title-color styling), default viewer registration, the fallback wiring in `Viewer.vue`, folder
   exclusion in the file action's `enabled` callback, and prev/next navigation.
2. **feat(viewer): hide file name in modal header for default/image view** — hides the file name in
   the modal header for the Default component and for images. Also keeps the header actions
   (play/pause, actions menu, close) right-aligned when the name is empty: `NcModal` omits the
   `.modal-header__name` element behind `v-if`, and its `.modal-header` relies on that full-width
   name to push `.icons-menu` right via flex `space-between` (no `margin-left: auto` fallback), so
   without it the actions collapsed to the left. Fixed with a scoped
   `:deep(.modal-header .icons-menu) { margin-inline-start: auto; }` — a no-op when the name is
   shown, right-aligning when it is hidden.
3. **fix(viewer): exclude directories from the file list**
4. **feat(viewer): exclude Collabora office documents and PDFs from preview**
5. **fix(images): render default fallback and stop spinner on failed image load**
6. **fix(viewer): fix live-photo peer match for numeric-name files**

Authorship across the folded commits is preserved via `Co-authored-by` + `Signed-off-by` trailers.

## Relationship to #45

Supersedes-in-spirit #45, but **both are intentionally left open** so reviewers can compare the
granular history (#45) against this folded, upstream-ready shape.

## Assets

The `chore(assets): recompile viewer assets for NC33 delta` commit has been **dropped** from this
branch. The compiled `js/`/`css/` assets still need to be **rebuilt and re-committed** to reflect
the source changes (notably the header-layout fix in feature 2) before this is merged.

## CI note

`static-psalm-analysis` fails on a **pre-existing base issue** unrelated to this delta: the psalm job
pulls `nextcloud/ocp dev-master`, which now requires PHP ~8.3, while the vanilla `composer.json`
`config.platform.php` is `8.2`. This affects any viewer fork PR until the base bumps the platform pin.

Jira: HDNEXT-1585
